### PR TITLE
squid:S2162 - equals methods should be symmetric and work for subclasses

### DIFF
--- a/plugins/io.sarl.eclipse/src/io/sarl/eclipse/runtime/AbstractSREInstall.java
+++ b/plugins/io.sarl.eclipse/src/io/sarl/eclipse/runtime/AbstractSREInstall.java
@@ -108,7 +108,15 @@ public abstract class AbstractSREInstall implements ISREInstall {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof ISREInstall) {
+		if (this == obj) {
+			return true;
+		}
+
+		if (obj == null) {
+			return false;
+		}
+
+		if (this.getClass() == obj.getClass()) {
 			return getId().equals(((ISREInstall) obj).getId());
 		}
 		return false;

--- a/plugins/io.sarl.lang.core/src/io/sarl/lang/core/Address.java
+++ b/plugins/io.sarl.lang.core/src/io/sarl/lang/core/Address.java
@@ -89,7 +89,15 @@ public class Address implements Serializable, Comparable<Address> {
 	@Override
 	@Pure
 	public boolean equals(Object obj) {
-		if (obj instanceof Address) {
+		if (this == obj) {
+			return true;
+		}
+
+		if (obj == null) {
+			return false;
+		}
+
+		if (this.getClass() == obj.getClass()) {
 			return equals((Address) obj);
 		}
 		return false;

--- a/plugins/io.sarl.lang/src/io/sarl/lang/actionprototype/ActionParameterTypes.java
+++ b/plugins/io.sarl.lang/src/io/sarl/lang/actionprototype/ActionParameterTypes.java
@@ -74,7 +74,15 @@ public class ActionParameterTypes extends BasicEList<String> implements Comparab
 
 	@Override
 	public boolean equals(Object object) {
-		if (super.equals(object) && object instanceof ActionParameterTypes) {
+		if (this == object) {
+			return true;
+		}
+
+		if (object == null) {
+			return false;
+		}
+
+		if (super.equals(object) && this.getClass() == object.getClass()) {
 			ActionParameterTypes types = (ActionParameterTypes) object;
 			return this.isVarargs == types.isVarargs;
 		}

--- a/plugins/io.sarl.lang/src/io/sarl/lang/actionprototype/ActionPrototype.java
+++ b/plugins/io.sarl.lang/src/io/sarl/lang/actionprototype/ActionPrototype.java
@@ -81,7 +81,12 @@ public class ActionPrototype implements Cloneable, Serializable, Comparable<Acti
 		if (obj == this) {
 			return true;
 		}
-		if (obj instanceof ActionPrototype) {
+
+		if (obj == null) {
+			return false;
+		}
+
+		if (this.getClass() == obj.getClass()) {
 			ActionPrototype k = (ActionPrototype) obj;
 			return this.function.equals(k.function)
 					&& this.signature.equals(k.signature);

--- a/plugins/io.sarl.lang/src/io/sarl/lang/actionprototype/QualifiedActionName.java
+++ b/plugins/io.sarl.lang/src/io/sarl/lang/actionprototype/QualifiedActionName.java
@@ -94,7 +94,12 @@ public class QualifiedActionName implements Cloneable, Serializable, Comparable<
 		if (obj == this) {
 			return true;
 		}
-		if (obj instanceof QualifiedActionName) {
+
+		if (obj == null) {
+			return false;
+		}
+
+		if (this.getClass() == obj.getClass()) {
 			QualifiedActionName k = (QualifiedActionName) obj;
 			return Objects.equal(this.resourceID, k.resourceID)
 					&& Objects.equal(


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2162 - "equals" methods should be symmetric and work for subclasses

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2162

Please let me know if you have any questions.

M-Ezzat