### PR TITLE
squid:S2063 - Comparators should be Serializable

### DIFF
--- a/plugins/io.sarl.lang/src/io/sarl/lang/util/ActionComparator.java
+++ b/plugins/io.sarl.lang/src/io/sarl/lang/util/ActionComparator.java
@@ -21,6 +21,7 @@
 
 package io.sarl.lang.util;
 
+import java.io.Serializable;
 import java.util.Comparator;
 
 import io.sarl.lang.sarl.SarlAction;
@@ -33,7 +34,8 @@ import io.sarl.lang.sarl.SarlAction;
  * @mavengroupid $GroupId$
  * @mavenartifactid $ArtifactId$
  */
-public class ActionComparator implements Comparator<SarlAction> {
+public class ActionComparator implements Comparator<SarlAction>, Serializable {
+	private static final long serialVersionUID = 6693376551313660666L;
 
 	private final FormalParameterListComparator comparator = new FormalParameterListComparator();
 

--- a/plugins/io.sarl.lang/src/io/sarl/lang/util/AttributeComparator.java
+++ b/plugins/io.sarl.lang/src/io/sarl/lang/util/AttributeComparator.java
@@ -21,6 +21,7 @@
 
 package io.sarl.lang.util;
 
+import java.io.Serializable;
 import java.util.Comparator;
 
 import io.sarl.lang.sarl.SarlField;
@@ -33,7 +34,8 @@ import io.sarl.lang.sarl.SarlField;
  * @mavengroupid $GroupId$
  * @mavenartifactid $ArtifactId$
  */
-public class AttributeComparator implements Comparator<SarlField> {
+public class AttributeComparator implements Comparator<SarlField>, Serializable {
+	private static final long serialVersionUID = 4577741984021468692L;
 
 	@Override
 	public int compare(SarlField o1, SarlField o2) {

--- a/plugins/io.sarl.lang/src/io/sarl/lang/util/BehaviorUnitComparator.java
+++ b/plugins/io.sarl.lang/src/io/sarl/lang/util/BehaviorUnitComparator.java
@@ -21,6 +21,7 @@
 
 package io.sarl.lang.util;
 
+import java.io.Serializable;
 import java.util.Comparator;
 
 import org.eclipse.xtext.xbase.XExpression;
@@ -35,7 +36,8 @@ import io.sarl.lang.sarl.SarlBehaviorUnit;
  * @mavengroupid $GroupId$
  * @mavenartifactid $ArtifactId$
  */
-public class BehaviorUnitComparator implements Comparator<SarlBehaviorUnit> {
+public class BehaviorUnitComparator implements Comparator<SarlBehaviorUnit>, Serializable {
+	private static final long serialVersionUID = 5331105342444861433L;
 
 	@Override
 	public int compare(SarlBehaviorUnit o1, SarlBehaviorUnit o2) {

--- a/plugins/io.sarl.lang/src/io/sarl/lang/util/ConstructorComparator.java
+++ b/plugins/io.sarl.lang/src/io/sarl/lang/util/ConstructorComparator.java
@@ -21,6 +21,7 @@
 
 package io.sarl.lang.util;
 
+import java.io.Serializable;
 import java.util.Comparator;
 
 import io.sarl.lang.sarl.SarlConstructor;
@@ -33,7 +34,8 @@ import io.sarl.lang.sarl.SarlConstructor;
  * @mavengroupid $GroupId$
  * @mavenartifactid $ArtifactId$
  */
-public class ConstructorComparator implements Comparator<SarlConstructor> {
+public class ConstructorComparator implements Comparator<SarlConstructor>, Serializable {
+	private static final long serialVersionUID = 1517387787287634067L;
 
 	private final FormalParameterListComparator comparator = new FormalParameterListComparator();
 

--- a/plugins/io.sarl.lang/src/io/sarl/lang/util/FormalParameterListComparator.java
+++ b/plugins/io.sarl.lang/src/io/sarl/lang/util/FormalParameterListComparator.java
@@ -21,6 +21,7 @@
 
 package io.sarl.lang.util;
 
+import java.io.Serializable;
 import java.util.Comparator;
 import java.util.Iterator;
 
@@ -36,7 +37,8 @@ import org.eclipse.xtext.common.types.JvmTypeReference;
  * @mavengroupid $GroupId$
  * @mavenartifactid $ArtifactId$
  */
-public class FormalParameterListComparator implements Comparator<EList<? extends XtendParameter>> {
+public class FormalParameterListComparator implements Comparator<EList<? extends XtendParameter>>, Serializable {
+	private static final long serialVersionUID = 1565477564314061872L;
 
 	@Override
 	public int compare(EList<? extends XtendParameter> left, EList<? extends XtendParameter> right) {

--- a/plugins/io.sarl.lang/src/io/sarl/lang/util/JvmIdentifiableComparator.java
+++ b/plugins/io.sarl.lang/src/io/sarl/lang/util/JvmIdentifiableComparator.java
@@ -21,6 +21,7 @@
 
 package io.sarl.lang.util;
 
+import java.io.Serializable;
 import java.util.Comparator;
 
 import org.eclipse.xtext.common.types.JvmIdentifiableElement;
@@ -33,7 +34,8 @@ import org.eclipse.xtext.common.types.JvmIdentifiableElement;
  * @mavengroupid $GroupId$
  * @mavenartifactid $ArtifactId$
  */
-public class JvmIdentifiableComparator implements Comparator<JvmIdentifiableElement> {
+public class JvmIdentifiableComparator implements Comparator<JvmIdentifiableElement>, Serializable {
+	private static final long serialVersionUID = 2267225783238047934L;
 
 	@Override
 	public int compare(JvmIdentifiableElement o1, JvmIdentifiableElement o2) {

--- a/plugins/io.sarl.lang/src/io/sarl/lang/util/JvmTypeReferenceComparator.java
+++ b/plugins/io.sarl.lang/src/io/sarl/lang/util/JvmTypeReferenceComparator.java
@@ -21,6 +21,7 @@
 
 package io.sarl.lang.util;
 
+import java.io.Serializable;
 import java.util.Comparator;
 
 import org.eclipse.xtext.common.types.JvmTypeReference;
@@ -33,7 +34,8 @@ import org.eclipse.xtext.common.types.JvmTypeReference;
  * @mavengroupid $GroupId$
  * @mavenartifactid $ArtifactId$
  */
-public class JvmTypeReferenceComparator implements Comparator<JvmTypeReference> {
+public class JvmTypeReferenceComparator implements Comparator<JvmTypeReference>, Serializable {
+	private static final long serialVersionUID = 4883341549153024937L;
 
 	@Override
 	public int compare(JvmTypeReference o1, JvmTypeReference o2) {

--- a/plugins/io.sarl.lang/src/io/sarl/lang/util/JvmVisibilityComparator.java
+++ b/plugins/io.sarl.lang/src/io/sarl/lang/util/JvmVisibilityComparator.java
@@ -21,6 +21,7 @@
 
 package io.sarl.lang.util;
 
+import java.io.Serializable;
 import java.util.Comparator;
 
 import org.eclipse.xtext.common.types.JvmVisibility;
@@ -33,7 +34,8 @@ import org.eclipse.xtext.common.types.JvmVisibility;
  * @mavengroupid $GroupId$
  * @mavenartifactid $ArtifactId$
  */
-public class JvmVisibilityComparator implements Comparator<JvmVisibility> {
+public class JvmVisibilityComparator implements Comparator<JvmVisibility>, Serializable {
+	private static final long serialVersionUID = 2651322953936550928L;
 
 	private static int getVisibilityLevel(JvmVisibility visibility) {
 		switch (visibility) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2063 - Comparators should be "Serializable"

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2063

Please let me know if you have any questions.

M-Ezzat