### PR TITLE
[sarlc] Addition of generic id for assembly to fix build issue

### DIFF
--- a/products/sarlc/with-dependencies.xml
+++ b/products/sarlc/with-dependencies.xml
@@ -2,7 +2,7 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
   <!-- TODO: a jarjar format would be better -->
-  <id>io.sarl.lang.sarlc</id>
+  <id>cli</id>
   <formats>
     <format>jar</format>
   </formats>

--- a/products/sarlc/with-dependencies.xml
+++ b/products/sarlc/with-dependencies.xml
@@ -2,7 +2,7 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
   <!-- TODO: a jarjar format would be better -->
-  <id></id>
+  <id>io.sarl.lang.sarlc</id>
   <formats>
     <format>jar</format>
   </formats>


### PR DESCRIPTION
Initial build of the sarl project lead to a build error in the project io.sarl.lang.sarlc. A text file is attached with the log of the build error, trimmed to contain relevant information. The main problem was the field <id> in the file with-dependencies.xml which was left blank.

This PR meant to fix this issue by filling this field with a (hopefully relevent) placeholder, until a proper method is designed.
[output.txt](https://github.com/sarl/sarl/files/1239023/output.txt)
.