### PR TITLE
Fix resource names for English version

### DIFF
--- a/contribs/io.sarl.examples/io.sarl.examples.plugin/projects/io-sarl-demos-fireworks/src/main/resources/io/sarl/demos/fireworks/gui/FireworksFxApplication.properties
+++ b/contribs/io.sarl.examples/io.sarl.examples.plugin/projects/io-sarl-demos-fireworks/src/main/resources/io/sarl/demos/fireworks/gui/FireworksFxApplication.properties
@@ -1,10 +1,10 @@
 TITLE=SARL Demo: Fireworks Animation
-SetupButton=Configure
-LaunchButton=Launch
-StopButton=Stop
-GravityLabel=Gravity
-RocketQuantityLabel=Rocket quantity
-FireQuantityLabel=Fire quantity
+SetupButtonText=Configure
+LaunchButtonText=Launch
+StopButtonText=Stop
+GravityLabelText=Gravity
+RocketQuantityLabelText=Rocket quantity
+FireQuantityLabelText=Fire quantity
 SetupButtonTooltip=Setup the entire environment according to the data given below
 LaunchButtonTooltip=Launch fireworks
 StopButtonTooltip=Stop and freeze fireworks


### PR DESCRIPTION
The example would not run in any English locale due to missing resource "SetupButtonText".  Several of the resources names needed to have the suffix "Text" included to match the fxml references.