### PR TITLE
Introducing changes to allow maven compilation with latest Xtext version

### DIFF
--- a/main/coreplugins/io.sarl.lang/META-INF/MANIFEST.MF
+++ b/main/coreplugins/io.sarl.lang/META-INF/MANIFEST.MF
@@ -23,7 +23,8 @@ Require-Bundle: io.sarl.lang.core;bundle-version="0.9.0";visibility:=reexport,
  org.eclipse.emf.common;bundle-version="2.15.0",
  org.eclipse.core.runtime;bundle-version="3.15.200",
  org.slf4j.api;bundle-version="1.7.2",
- org.apache.commons.io;bundle-version="2.6.0"
+ org.apache.commons.io;bundle-version="2.6.0",
+ com.google.inject;bundle-version="4.1.0"
 Bundle-Activator: io.sarl.lang.SARLLangActivator
 Export-Package: io.sarl.lang,
  io.sarl.lang.bugfixes.pending.bug621,

--- a/main/externalmaven/io.sarl.maven.docs.generator/src/main/java/io/sarl/maven/docs/parser/SarlDocumentationParser.java
+++ b/main/externalmaven/io.sarl.maven.docs.generator/src/main/java/io/sarl/maven/docs/parser/SarlDocumentationParser.java
@@ -2134,6 +2134,9 @@ public class SarlDocumentationParser {
 									final String stringResult = Strings.nullToEmpty(Objects.toString(result));
 									return stringResult;
 								}
+							} catch (IllegalStateException e) {
+								// Triggered when a documentation file does not contain Xtext code
+								// It is ignored
 							} catch (Exception exception) {
 								Throwables.propagate(exception);
 							}
@@ -2204,6 +2207,9 @@ public class SarlDocumentationParser {
 									final String stringResult = Strings.nullToEmpty(Objects.toString(result));
 									return formatBlockText(stringResult, context.getOutputLanguage(), context.getBlockCodeFormat());
 								}
+							} catch (IllegalStateException e) {
+								// Triggered when a documentation file does not contain Xtext code
+								// It is ignored
 							} catch (Exception exception) {
 								Throwables.propagate(exception);
 							}

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
 		<javaxinject.version>1</javaxinject.version>
 		<!-- Version of the Tycho module, (search for tycho-maven-plugin on Maven 
 			central) -->
-		<tycho.version>1.3.0</tycho.version>
+		<tycho.version>1.4.0</tycho.version>
 		<!-- Version of the ZeroMQ library -->
 		<zeromq.version>0.5.0</zeromq.version>
 		<!-- Version of the SWT library -->

--- a/products/updatesite/io.sarl.lang.product
+++ b/products/updatesite/io.sarl.lang.product
@@ -305,9 +305,9 @@
    </features>
 
    <configurations>
+      <plugin id="org.apache.felix.scr" autoStart="false" startLevel="0" />
       <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="4" />
       <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2" />
-      <plugin id="org.eclipse.equinox.ds" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.event" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.p2.reconciler.dropins" autoStart="true" startLevel="0" />
       <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="false" startLevel="1" />

--- a/sre/io.janusproject/io.janusproject.tests/src/test/java/io/janusproject/tests/modules/hazelcast/AbstractSerializerTest.java
+++ b/sre/io.janusproject/io.janusproject.tests/src/test/java/io/janusproject/tests/modules/hazelcast/AbstractSerializerTest.java
@@ -215,11 +215,6 @@ abstract class AbstractSerializerTest extends AbstractJanusTest {
 			return content;
 		}
 
-		@Override
-		public SerializationService getSerializationService() {
-			throw new UnsupportedOperationException();
-		}
-
 	}
 
 	/**

--- a/sre/io.janusproject/io.janusproject.tests/src/test/java/io/janusproject/tests/testutils/HzMultiMapMock.java
+++ b/sre/io.janusproject/io.janusproject.tests/src/test/java/io/janusproject/tests/testutils/HzMultiMapMock.java
@@ -256,11 +256,6 @@ public class HzMultiMapMock<K, V> implements MultiMap<K, V> {
 		throw new UnsupportedOperationException();
 	}
 
-	@Override
-	public void delete(Object arg0) {
-		throw new UnsupportedOperationException();
-	}
-
 	/**
 	 * @author $Author: sgalland$
 	 * @version $FullVersion$

--- a/tycho-parent/pom.xml
+++ b/tycho-parent/pom.xml
@@ -46,22 +46,12 @@
 						<environment>
 							<os>win32</os>
 							<ws>win32</ws>
-							<arch>x86</arch>
-						</environment>
-						<environment>
-							<os>win32</os>
-							<ws>win32</ws>
 							<arch>x86_64</arch>
 						</environment>
 						<environment>
 							<os>macosx</os>
 							<ws>cocoa</ws>
 							<arch>x86_64</arch>
-						</environment>
-						<environment>
-							<os>linux</os>
-							<ws>gtk</ws>
-							<arch>x86</arch>
 						</environment>
 						<environment>
 							<os>linux</os>


### PR DESCRIPTION
Main changes:
- In main/coreplugins/io.sarl.lang/META-INF/MANIFEST.MF, explicitly adding Guice 4.1.0 as required bundle
- Removing reference to org.eclipse.equinox.ds in products/updatesite/io.sarl.lang.product (https://bugs.eclipse.org/bugs/show_bug.cgi?id=538737)
- Removing support for x86 architectures in tycho-parent/pom.xml (looks like required dependencies don't exists anymore in the P2 repositories http://download.eclipse.org/releases/2019-03/)
- Updating tycho version to 1.4.0

<!---
@huboard:{"order":849.0,"milestone_order":905,"custom_state":""}
-->
