### PR TITLE
Re-enabling the packaging of Sierpinski Fractals example

### DIFF
--- a/contribs/io.sarl.examples/io.sarl.examples.plugin/src-templates/build.xml
+++ b/contribs/io.sarl.examples/io.sarl.examples.plugin/src-templates/build.xml
@@ -24,7 +24,7 @@
 		<zip_example name="io-sarl-tutorials-pingpong" />
 		<zip_example name="io-sarl-tutorials-pingpongspace" />
 		<zip_example name="io-sarl-demos-fireworks" />
-		<!--<zip_example name="io-sarl-demos-sierpinskifractals" />-->
+		<zip_example name="io-sarl-demos-sierpinskifractals" />
 		<zip_example name="io-sarl-demos-gameoflife" />
 		<zip_example name="io-sarl-templates-javafx" />
 	</target>


### PR DESCRIPTION
Sierpinski Fractals are working but the Zip file is not included with the editor.
This commit re-enables the inclusion of the Zip of this example so it can be created as a new project.